### PR TITLE
ヘルパーメソッドのコード改善

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -12,7 +12,6 @@ module ArticlesHelper
 
   def selected_sort
     if params[:q].nil?
-      params[:q] = @q
       params[:q] = {sorts: 'created_at desc'}
     else
       params[:q][:sorts]


### PR DESCRIPTION
selected_sortメソッドで、`params[:q] = @q`　が不要だったので削除